### PR TITLE
WIP: add import and export sections

### DIFF
--- a/src/wasm.jl
+++ b/src/wasm.jl
@@ -104,6 +104,8 @@ struct Module
   funcs::Vector{Func}
 end
 
+Module() = Module(Vector{Import}[], Vector{Export}[], Vector{Func}[])
+
 # Printing
 
 Base.show(io::IO, i::Nop)      = print(io, "nop")
@@ -171,7 +173,7 @@ function printwasm(io, x::Import, level)
 end
 
 function Base.show(io::IO, f::Func)
-  print(io, "(func")
+  print(io, "(func \$$(f.name) ")
   foreach(p -> print(io, " (param $p)"), f.params)
   foreach(p -> print(io, " (result $p)"), f.returns)
   if !isempty(f.locals)
@@ -183,13 +185,13 @@ function Base.show(io::IO, f::Func)
 end
 
 function printwasm(io::IO, f::Func, level)
-  print(io, "(func")
-  printwasm_(io, f.body.body, 1)
-  foreach(p -> printwasm_(io, " (param $p)", level + 1), f.params)
-  foreach(p -> printwasm_(io, " (result $p)", level + 1), f.returns)
+  print(io, "\n", "  "^(level))
+  print(io, "(func \$$(f.name) ")
+  foreach(p -> print(io, " (param $p)"), f.params)
+  foreach(p -> print(io, " (result $p)"), f.returns)
   if !isempty(f.locals)
     print(io, "\n ")
-    foreach(p -> printwasm_(io, " (local $p)", level + 1), f.locals)
+    foreach(p -> print(io, " (local $p)"), f.locals)
   end
   printwasm_(io, f.body.body, level + 1)
   print(io, ")")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,21 @@
 using WebAssembly
 using WebAssembly.Instructions
+using WebAssembly: WType, Func, Module, Import, Export, i32, f64
 using Base.Test
 
 @testset "WebAssembly" begin
 
 b = Block([Nop(), Nop()]) |> WebAssembly.nops
 @test isempty(b.body)
+
+end
+
+@testset "Import-export" begin
+
+m = Module([Import(:env, :mathfun, :func, [i32, f64])],
+           [Export(:fun, :func),
+            Export(:fun2, :func)],
+           Func[])
+
 
 end


### PR DESCRIPTION
This is a start at adding import and export sections to a wasm module. Imports could look something like the following on the Charlotte side:

```julia
@import env.sin(Float64)::Float64
```
This would become:
```julia
function sin(::Float64)
    Expr(:meta, (:env, :sin, Float64, Tuple{Float64}))
    nothing
end
```
Then, that would be transformed into a `call` in wasm when `sin` is parsed. Instead of Julia types given above, those could be wasm types.

Exports could be picked up as follows:
```julia
function mathfun(x)
    x + sin(x)
end

m = @wasm begin
    mathfun(Float64)
    # Enter more functions here...
end
write("test.wat", m)
```
