### PR TITLE
Additions to support invoke in Charlotte

### DIFF
--- a/src/WebAssembly.jl
+++ b/src/WebAssembly.jl
@@ -7,10 +7,10 @@ include("looper.jl")
 module Instructions
 
 using ..WebAssembly: Instruction, Const, Nop, Local, SetLocal, Op, Select, Convert,
-  Block, If, Loop, Branch, Return, Unreachable, Label, Goto, nop, unreachable
+  Block, If, Loop, Branch, Call, Return, Unreachable, Label, Goto, nop, unreachable
 
 export Instruction, Const, Nop, Local, SetLocal, Op, Select, Convert,
-  Block, If, Loop, Branch, Return, Unreachable, Label, Goto, nop, unreachable
+  Block, If, Loop, Branch, Call, Return, Unreachable, Label, Goto, nop, unreachable
 
 end
 

--- a/src/wasm.jl
+++ b/src/wasm.jl
@@ -70,6 +70,10 @@ struct Branch <: Instruction
   level::Int
 end
 
+struct Call <: Instruction
+  name::Symbol
+end
+
 Branch(l::Integer) = Branch(false, l)
 
 struct Return <: Instruction end
@@ -95,6 +99,7 @@ end
 
 struct Export
   name::Symbol
+  internalname::Symbol
   typ::Symbol   # :func, :table, :memory, :global
 end
 
@@ -113,6 +118,7 @@ Base.show(io::IO, i::Const)    = print(io, i.typ, ".const ", value(i))
 Base.show(io::IO, i::Local)    = print(io, "get_local ", i.id)
 Base.show(io::IO, i::SetLocal) = print(io, i.tee ? "tee_local" : "set_local ", i.id)
 Base.show(io::IO, i::Op)       = print(io, i.typ, ".", i.name)
+Base.show(io::IO, i::Call)     = print(io, "call \$", i.name)
 Base.show(io::IO, i::Convert)  = print(io, i.to, ".", i.name, "/", i.from)
 Base.show(io::IO, i::Select)   = print(io, "select")
 Base.show(io::IO, i::Branch)   = print(io, i.cond ? "br_if " : "br ", i.level)
@@ -158,7 +164,7 @@ Base.show(io::IO, i::Union{Block,Loop,If}) = printwasm(io, i, 0)
 
 function printwasm(io, x::Export, level)
   print(io, "\n", "  "^(level))
-  print(io, "(export \"$(x.name)\" ($(x.typ) \$$(x.name)))")
+  print(io, "(export \"$(x.name)\" ($(x.typ) \$$(x.internalname)))")
 end
 
 function printwasm(io, x::Import, level)

--- a/src/wasm.jl
+++ b/src/wasm.jl
@@ -99,12 +99,12 @@ struct Export
 end
 
 struct Module
-  imports::Vector{Import}
-  exports::Vector{Export}
-  funcs::Vector{Func}
+  imports::Dict
+  exports::Dict
+  funcs::Dict
 end
 
-Module() = Module(Vector{Import}[], Vector{Export}[], Vector{Func}[])
+Module() = Module(Dict(), Dict(), Dict())
 
 # Printing
 
@@ -199,8 +199,8 @@ end
 
 function Base.show(io::IO, m::Module)
   print(io, "(module")
-  foreach(p -> printwasm(io, p, 1), m.imports)
-  foreach(p -> printwasm(io, p, 1), m.exports)
-  foreach(p -> printwasm(io, p, 1), m.funcs)
+  foreach(p -> printwasm(io, p[2], 1), m.imports)
+  foreach(p -> printwasm(io, p[2], 1), m.exports)
+  foreach(p -> printwasm(io, p[2], 1), m.funcs)
   print(io, ")")
 end

--- a/src/wasm.jl
+++ b/src/wasm.jl
@@ -104,6 +104,8 @@ struct Module
   funcs::Vector{Func}
 end
 
+Module() = Module(Vector{Import}[], Vector{Export}[], Vector{Func}[])
+
 # Printing
 
 Base.show(io::IO, i::Nop)      = print(io, "nop")
@@ -171,7 +173,7 @@ function printwasm(io, x::Import, level)
 end
 
 function Base.show(io::IO, f::Func)
-  print(io, "(func")
+  print(io, "(func \$$(f.name) ")
   foreach(p -> print(io, " (param $p)"), f.params)
   foreach(p -> print(io, " (result $p)"), f.returns)
   if !isempty(f.locals)
@@ -183,13 +185,13 @@ function Base.show(io::IO, f::Func)
 end
 
 function printwasm(io::IO, f::Func, level)
-  print(io, "(func")
-  printwasm_(io, f.body.body, 1)
-  foreach(p -> printwasm_(io, " (param $p)", level + 1), f.params)
-  foreach(p -> printwasm_(io, " (result $p)", level + 1), f.returns)
+  print(io, "\n", "  "^(level))
+  print(io, "(func \$$(f.name) ")
+  foreach(p -> print(io, " (param $p)"), f.params)
+  foreach(p -> print(io, " (result $p)"), f.returns)
   if !isempty(f.locals)
     print(io, "\n ")
-    foreach(p -> printwasm_(io, " (local $p)", level + 1), f.locals)
+    foreach(p -> print(io, " (local $p)"), f.locals)
   end
   printwasm_(io, f.body.body, level + 1)
   print(io, ")")

--- a/src/wasm.jl
+++ b/src/wasm.jl
@@ -95,6 +95,7 @@ struct Import
   name::Symbol
   typ::Symbol   # :func, :table, :memory, :global
   params::Vector{WType}
+  returntype::WType
 end
 
 struct Export
@@ -169,11 +170,12 @@ end
 
 function printwasm(io, x::Import, level)
   print(io, "\n", "  "^(level))
-  print(io, "(import \"$(x.mod)\" \"$(x.name)\" ($(x.typ) \$$(x.name)")
+  print(io, "(import \"$(x.mod)\" \"$(x.name)\" ($(x.typ) \$$(x.mod)_$(x.name)")
   if x.typ == :func && length(x.params) > 0
     print(io, " (param")
     foreach(p -> print(io, " $p"), x.params)
     print(io, ")")
+    print(io, " (result ", x.returntype, ")")
   end
   print(io, "))")
 end

--- a/src/wasm.jl
+++ b/src/wasm.jl
@@ -105,12 +105,10 @@ struct Export
 end
 
 struct Module
-  imports::Dict
-  exports::Dict
-  funcs::Dict
+  imports::Vector{Import}
+  exports::Vector{Export}
+  funcs::Vector{Func}
 end
-
-Module() = Module(Dict(), Dict(), Dict())
 
 # Printing
 
@@ -207,8 +205,8 @@ end
 
 function Base.show(io::IO, m::Module)
   print(io, "(module")
-  foreach(p -> printwasm(io, p[2], 1), m.imports)
-  foreach(p -> printwasm(io, p[2], 1), m.exports)
-  foreach(p -> printwasm(io, p[2], 1), m.funcs)
+  foreach(p -> printwasm(io, p, 1), m.imports)
+  foreach(p -> printwasm(io, p, 1), m.exports)
+  foreach(p -> printwasm(io, p, 1), m.funcs)
   print(io, ")")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,21 @@
 using WebAssembly
 using WebAssembly.Instructions
+using WebAssembly: WType, Func, Module, Import, Export, i32, f64
 using Base.Test
 
 @testset "WebAssembly" begin
 
 b = Block([Nop(), Nop()]) |> WebAssembly.nops
 @test isempty(b.body)
+
+end
+
+@testset "Import-export" begin
+
+m = Module([Import(:env, :mathfun, :func, [i32, f64])],
+           [Export(:fun, :func),
+            Export(:fun2, :func)],
+           Func[])
+
 
 end


### PR DESCRIPTION
This builds on #4. It adds support for `Call`. It also changes the contents of `Module` from `Vector` to `Dict`. That helps with look-ups.  