### PR TITLE
Optimisation: Register Allocation

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -100,6 +100,7 @@ apInstr(i::Nop,         ms) = Void()
 apInstr(i::Local,       ms) = push!(ms,ms[i.id + 1]);
 apInstr(i::Const,       ms) = push!(ms,value(i));
 apInstr(i::Unreachable, ms) = error("Unreachable")
+apInstr(i::Drop, ms)        = pop!(ms)
 apInstr(i::Convert,     ms) = push!(ms, convert(jltype(i.to), float(pop!(ms))))
 apInstr(i::Op,          ms) = operations[i.name](ms)
 

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -80,7 +80,7 @@ function rmblocks(code)
   end
 end
 
-optimise(b) = b |> deadcode |> makeifs |> rmblocks
+optimise(b) = b |> deadcode |> makeifs |> rmblocks |> allocate_registers
 
 using LightGraphs
 

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -84,215 +84,150 @@ optimise(b) = b |> deadcode |> makeifs |> rmblocks
 
 using LightGraphs
 
+liveness(code::Func, as...; ks...) = liveness(code.body.body, as...; ks...)
+
+function liveness_(x::Local, i, alive, branch, rig, lines, as...)
+  id = get!(alive, x.id) do
+    lines != nothing && push!(lines, [])
+    rig isa Ref && return rig.x += 1
+    add_vertex!(rig) || error()
+    id = nv(rig)
+    for v in values(alive)
+      add_edge!(rig, id, v)
+    end
+    return id
+  end
+  lines != nothing && push!(lines[id], push!(copy(branch), i))
+end
+
+function liveness_(x::SetLocal, i, alive, branch, rig, lines, perm_alive, skippedsets)
+  if haskey(alive, x.id)
+    id = alive[x.id]
+    if !haskey(perm_alive, x.id)
+      delete!(alive, x.id)
+    end
+    lines != nothing && push!(lines[id], push!(copy(branch), i))
+  else
+    skippedsets != nothing && push!(skippedsets, push!(copy(branch), i))
+  end
+end
+
+function liveness_(x::Union{Block, Loop}, i, alive, branch, branches, as... ; ks...)
+  push!(branches, (copy(alive), x isa Loop))
+  push!(branch, i)
+  liveness(x.body, alive, branch, branches, as...; ks...)
+  pop!(branch)
+  pop!(branches)
+end
+
+function liveness_(x::If, i, alive, branch, as... ; ks...)
+  push!(branch, i)
+  a_t = copy(alive)
+  liveness_(Block(x.t), 1, a_t, branch, as...; ks...)
+  liveness_(Block(x.f), 2, alive, branch, as...; ks...)
+  pop!(branch)
+  merge!(alive, a_t)
+end
+
+function liveness_(x::Branch, code, i, alive, branch, branches, perm_alive, rig, lines; ks...)
+  br = branches[end-x.level]
+  x.cond ? merge!(alive, copy(br[1])) : merge!(empty!(alive), copy(br[1]))
+  if !br[2] # If not branching to a loop.
+    liveness(code[1:i-1], alive, branch, branches, perm_alive; rig=rig, lines=lines, ks...)
+  else
+    # First pass of loop to get alive set after loop.
+    a_f = liveness(code[1:i-1], copy(alive), branch, branches, alive; rig=Ref{Int}(nv(rig)))
+
+    a_diff = Dict(a => (add_vertex!(rig); nv(rig)) for (a, _) in setdiff(a_f, alive))
+    merge!(alive, a_diff)
+    for (a, v) in a_diff
+      push!(lines, [])
+      for v_ in values(alive)
+        v == v_ && continue
+        add_edge!(rig, v, v_)
+      end
+    end
+
+    # Second pass of loop using the calculated alive set.
+    liveness(code[1:i-1], alive, branch, branches, copy(alive); rig=rig, lines=lines, ks...)
+  end
+end
+
 # rig is the Register Interference Graph. out_neighbors(value id, rig) will give
 # the ids of the values that are alive at the same time as the given value id.
 
 # lines takes a value id and returns references to all the get/sets in the code
 # so they can be updated quickly later.
 
+# skippedsets is any encountered set where the value isn't used.
+
 # alive is essentially a set of currently used registers, but with the id of the
 # value stored.
 
-function liveness(func::Func)
-  rig = SimpleGraph()
-  alive = Dict{Int, Int}()
-  lines = Vector{Vector{Vector{Int}}}()
-  skippedsets = Vector()
-  alive = liveness_(func.body.body; rig=rig, lines=lines, alive=alive, skippedsets=skippedsets)
-  # @show alive
-  @show skippedsets
-  @show map(length, lines) |> sum
-  return rig, alive, lines, skippedsets
-end
-
-function liveness_(code; rig::Union{Ref{Int}, SimpleGraph}=Ref{Int}(0), lines::Union{Void, Vector{Vector{Vector{Int}}}}=nothing, alive::Dict{Int, Int}=Dict{Int, Int}(), branches=[], branch=[], skippedsets::Union{Void, Vector}=nothing, perm_alive::Dict=Dict())
+function liveness( code::Vector{Instruction}
+                 , alive::Dict{Int, Int}=Dict{Int, Int}()
+                 , branch::Vector{Int}=Vector{Int}()
+                 , branches::Vector{Tuple{Dict{Int,Int},Bool}}=Vector{Tuple{Dict{Int,Int},Bool}}()
+                 , perm_alive::Dict{Int, Int}=Dict{Int, Int}()
+                 ; rig::Union{Ref{Int}, SimpleGraph{Int}}=Ref{Int}(0)
+                 , lines::Union{Void, Vector{Vector{Vector{Int}}}}=nothing
+                 , skippedsets::Union{Void, Vector{Vector{Int}}}=nothing
+                 )
   for i in length(code):-1:1
     x = code[i]
-    if x isa Local
-      # @show x, alive
-      id = get!(alive, x.id) do
-        # id =
-        # if loop && haskey(branches[end][1], x.id)
-        #   # println("So this happens, $x")
-        #   error("not any more!")
-        #   branches[end][1][x.id]
-        # else
-        lines != nothing && push!(lines, [])
-        rig isa Ref && return rig.x += 1
-        add_vertex!(rig)
-        id = nv(rig)
-        # end
-        for v in values(alive)
-          add_edge!(rig, id, v)
-        end
-        return id
-      end
-      lines != nothing && push!(lines[id], push!(deepcopy(branch), i))
-      # @show code[i], i
-    # @show alive
-    elseif x isa SetLocal
-      # @show x
-      if haskey(alive, x.id)
-        id = alive[x.id]
-        if !haskey(perm_alive, x.id)
-          delete!(alive, x.id)
-        end
-        lines != nothing && push!(lines[id], push!(deepcopy(branch), i))
-        # @show code[i]
-        # push!(lines, id => Ref(code, i))
-      else
-        # TODO: Add support for drop / backprop to remove need for Drop.
-        skippedsets != nothing && push!(skippedsets, push!(deepcopy(branch), i))
-      end
-    elseif x isa Block || x isa Loop
-      push!(branches, (copy(alive), x isa Loop))
-      push!(branch, i)
-      alive = liveness_(code[i].body; rig=rig, lines=lines, alive=alive, branches=branches, branch=branch, skippedsets=skippedsets, perm_alive=perm_alive)
-      @show sum(map(length, lines))
-      @show alive
-      pop!(branch)
-      pop!(branches)
-    elseif x isa If
-      a_t = copy(alive)
-      a_f = copy(alive)
-      push!(branches, (copy(alive), false))
-      push!(branch, i, 1)
-      a_t = liveness_(code[i].t; rig=rig, lines=lines, alive=a_t, branches=branches, branch=branch, skippedsets=skippedsets, perm_alive=perm_alive)
-      pop!(branch)
-      push!(branch, 2)
-      a_f = liveness_(code[i].f; rig=rig, lines=lines, alive=a_f, branches=branches, branch=branch, skippedsets=skippedsets, perm_alive=perm_alive)
-      # a_f = liveness_(code[i].f, rig, lines, a_f, branches, branch, loop, skippedsets, perm_alive)
-      pop!(branch)
-      pop!(branches)
-      alive = merge(a_t, a_f)
+    if x isa Local || x isa SetLocal
+      liveness_(x, i, alive, branch, rig, lines, perm_alive, skippedsets)
+    elseif x isa Block || x isa Loop || x isa If
+      liveness_(x, i, alive, branch, branches, perm_alive; rig=rig, lines=lines, skippedsets=skippedsets)
     elseif x isa Branch
-      # At a branch need to revert the state of alive to what it was just after
-      # the block. (I.e. just before in terms of calculation order.)
-
-
-      br = branches[end-x.level]
-      a_b = x.cond ? merge(alive, copy(br[1])) : copy(br[1])
-      if !br[2] # If not branching to a loop.
-        a_b = liveness_(code[1:i-1]; rig=rig, lines=lines, alive=a_b, branches=branches, branch=branch, skippedsets=skippedsets, perm_alive=perm_alive)
-      else
-        # First pass of loop to get alive set after loop.
-        a_f = liveness_(code[1:i-1], rig=Ref{Int}(nv(rig)), alive=deepcopy(a_b), branches=branches, branch=branch, perm_alive=deepcopy(a_b))
-
-        a_diff = Dict(a => (add_vertex!(rig); nv(rig)) for (a, _) in setdiff(a_f, a_b))
-
-
-        a_new = merge(a_diff, a_b)
-        for (a, v) in a_diff
-          push!(lines, [])
-          for v_ in values(a_new)
-            v == v_ && continue
-            add_edge!(rig, v, v_)
-          end
-        end
-
-        # Second pass of loop using the calculated alive set.
-        a_b = liveness_(code[1:i-1], rig=rig, lines=lines, alive=a_new, branches=branches, branch=branch, skippedsets=skippedsets, perm_alive=deepcopy(a_new))
-
-        # for a in setdiff(a_f, a_b)
-        #   push!(lines, [])
-        # end
-        # liveness(s_sets, rig, lines, alive, branches)
-        # @show (1, alive)
-        # s_sets will be in reverse order as required.
-
-      #   for s in s_sets
-      #     set = get_instr(code, s[length(branches)+1:end])
-      #     @show set
-      #     if haskey(a_b, set.id)
-      #       push!(lines[a_b[set.id]], s)
-      #       @show set
-      #     else
-      #       push!(skippedsets, s)
-      #     end
-      #   end
-      end
-
-
-      # if x.cond
-      #   a_f = copy(alive)
-      #   # It should be possible to calculate this instead of starting over.
-      #   a_f = liveness_(code[1:i-1], deepcopy(rig), deepcopy(lines), a_f, branches, branch, loop, skippedsets)
-      #   @show alive
-      #   @show a_b, a_f
-      #   merge!(a_b, a_f)
-      # end
-      # TODO: Might want to give a warning about deadcode here on unconditional
-      # branches that come after some code.
-      alive = a_b
+      liveness_(x, code, i, alive, branch, branches, perm_alive, rig, lines; skippedsets=skippedsets)
       break
     end
   end
-
-  # if loop
-  #   return alive
-  # elseif !isempty(skippedsets)
-  #   println("Warning: Setting locals but values aren't used (Can replace with Drop).")
-  #   println((map(getindex, skippedsets), map(s -> s, skippedsets)))
-  # end
   return alive
 end
 
+get_line(code, branch) = apply_line(code, copy(branch), x->x)
+set_line(code, branch, y) = apply_line(code, copy(branch), x->y)
+modify_line(f, code, branch) = apply_line(code, copy(branch), f)
 
-get_instr(code, branch) = get_at_loc(code, deepcopy(branch), x->x)
-
-set_instr(code, branch, y) = get_at_loc(code, deepcopy(branch), x->y)
-modify_instr(f, code, branch) = get_at_loc(code, deepcopy(branch), f)
-
-function get_at_loc(code::Vector{Instruction}, branch, f)
-  b = shift!(branch)
-  if isempty(branch)
-    return code[b] = f(code[b])
-  else
-    return get_at_loc(code[b], branch, f)
-  end
-end
-get_at_loc(code::Func, branch, f) = get_at_loc(code.body.body, branch, f)
-get_at_loc(code::Union{Block, Loop}, branch, f) = get_at_loc(code.body, branch, f)
-function get_at_loc(code::If, branch, f)
-  b = shift!(branch)
-  if b == 1
-    return get_at_loc(code.t, branch, f)
-  elseif b == 2
-    return get_at_loc(code.f, branch, f)
-  end
-  error()
-end
+apply_line(i::Func, bs, f) = apply_line(i.body.body, bs, f)
+apply_line(i::Union{Block, Loop}, bs, f) = apply_line(i.body, bs, f)
+apply_line(i::If, bs, f) = bs |> shift! |> b -> apply_line(getfield(i, b), bs, f)
+apply_line(i::Vector, bs, f) = bs |> shift! |> b -> isempty(bs) ? i[b] = f(i[b]) : apply_line(i[b], bs, f)
 
 
 function allocate_registers(func::Func)
-  rig, alive, lines, skippedsets = func |> liveness
+  rig = SimpleGraph{Int}()
+  lines = Vector{Vector{Vector{Int}}}()
+  skippedsets = Vector{Vector{Int}}()
+  alive = liveness(func; rig=rig, lines=lines, skippedsets=skippedsets)
+
   coloring = rig |> greedy_color
-  length(alive) == length(func.params) || error("Not all parameters are used.")
-  @show coloring
-  @show alive
+
+  length(alive) == length(func.params) || println("Not all parameters are used.")
+
   c_to_r = Dict(coloring.colors[v] => r for (r, v) in alive)
   i = length(c_to_r) -1
   register_colours = [haskey(c_to_r, c) ? c_to_r[c] : i+=1 for c in 1:coloring.num_colors]
 
-  @show register_colours
-  @show coloring.colors
-
   col(value_id) = register_colours[coloring.colors[value_id]]
   for v in eachindex(lines)
     for l in lines[v]
-      modify_instr(func, l) do s
+      modify_line(func, l) do s
         s isa Local ? Local(col(v)) : (s isa SetLocal ? SetLocal(s.tee, col(v)) : error())
-        # s isa Local ? Local(v) : (s isa SetLocal ? SetLocal(s.tee, v) : error())
       end
     end
   end
 
+  # This is necessary as the register hasn't been updated and might interfere
+  # with operation.
+  # TODO: Drop removal, not possible in all cases. (E.g.: a conditional drop)
+  isempty(skippedsets) || println("Some sets aren't used, replacing with drop.")
   for s in skippedsets
-    set_instr(func, s, Drop())
+    set_line(func, s, Drop())
   end
-  @show coloring
-  @show func.params
-  @show func.locals
+
   locals = func.locals[1:coloring.num_colors-length(func.params)]
   return Func(func.name, func.params, func.returns, locals, func.body)
 end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -93,15 +93,21 @@ using LightGraphs
 # alive is essentially a set of currently used registers, but with the id of the
 # value stored.
 
-function liveness(code, rig=SimpleGraph(), lines=Dict{Int, Vector{Ref}}(), alive=Dict{Int, Int}(), prev_alive=[], first_pass_loop::Bool=false, skippedsets=Vector())
+function liveness(func::Func)
+  rig = SimpleGraph()
+  liveness_(func.body.body, rig)
+  return rig
+end
+
+function liveness_(code, rig=SimpleGraph(), lines=Dict{Int, Vector{Ref}}(), alive=Dict{Int, Int}(), branches=[], loop::Bool=false, skippedsets=Vector())
   for i in length(code):-1:1
     x = code[i]
     if x isa Local
-      @show x, alive
+      # @show x, alive
       id = get!(alive, x.id) do
-        id = if (@show first_pass_loop) && haskey(prev_alive[end], x.id)
-          println("So this happens, $x")
-          prev_alive[end][x.id]
+        id = if loop && haskey(branches[end][1], x.id)
+          # println("So this happens, $x")
+          branches[end][x.id]
         else
           add_vertex!(rig)
           nv(rig)
@@ -113,10 +119,10 @@ function liveness(code, rig=SimpleGraph(), lines=Dict{Int, Vector{Ref}}(), alive
         return id
       end
       push!(lines, id => push!(lines[id], Ref(code, i)))
-    @show alive
+    # @show alive
     elseif x isa SetLocal
-      @show x
-      if x.id in keys(alive)
+      # @show x
+      if haskey(alive, x.id)
         id = alive[x.id]
         delete!(alive, x.id)
         push!(lines, id => push!(lines[id], Ref(code, i)))
@@ -125,92 +131,66 @@ function liveness(code, rig=SimpleGraph(), lines=Dict{Int, Vector{Ref}}(), alive
         # TODO: Add support for drop / backprop to remove need for Drop.
         push!(skippedsets, Ref(code, i))
       end
-    elseif x isa Block
-      push!(prev_alive, copy(alive))
-      alive = liveness(code[i].body, rig, lines, alive, prev_alive, first_pass_loop, skippedsets)
-      pop!(prev_alive)
+    elseif x isa Block || x isa Loop
+      push!(branches, (copy(alive), x isa Loop))
+      alive = liveness_(code[i].body, rig, lines, alive, branches, loop, skippedsets)
+      pop!(branches)
     elseif x isa If
       a_t = copy(alive)
       a_f = copy(alive)
-      push!(prev_alive, copy(alive))
-      a_t = liveness(code[i].t, rig, lines, a_t, prev_alive, first_pass_loop, skippedsets)
-      a_f = liveness(code[i].f, rig, lines, a_f, prev_alive, first_pass_loop, skippedsets)
-      pop!(prev_alive)
+      push!(branches, (copy(alive), false))
+      a_t = liveness_(code[i].t, rig, lines, a_t, branches, loop, skippedsets)
+      a_f = liveness_(code[i].f, rig, lines, a_f, branches, loop, skippedsets)
+      pop!(branches)
       alive = merge(a_t, a_f)
     elseif x isa Branch
       # At a branch need to revert the state of alive to what it was just after
       # the block. (I.e. just before in terms of calculation order.)
-      if x.cond
-        a_t = copy(prev_alive[end-x.level])
-        a_f = copy(alive)
-        a_t = liveness(code[1:i-1], rig, lines, a_t, prev_alive, first_pass_loop, skippedsets)
-        a_f = liveness(code[1:i-1], rig, lines, a_f, prev_alive, first_pass_loop, skippedsets)
-        alive = merge(a_t, a_f)
-        break;
+
+
+      br = branches[end-x.level]
+      a_b = copy(br[1])
+      if !br[2] # If branching to a loop.
+        a_b = liveness_(code[1:i-1], rig, lines, a_b, branches, loop, skippedsets)
       else
-        # error("no non conditional branches")
-        a_b = copy(prev_alive[end-x.level])
-        a_b = liveness(code[1:i-1], rig, lines, a_b, prev_alive, first_pass_loop, skippedsets)
-        alive = a_b
-        break
-      end
-    elseif x isa Loop
-      push!(prev_alive, copy(alive))
-      s_sets = Vector();
-      alive = liveness(code[i].body, rig, lines, alive, prev_alive, true, s_sets)
-      # liveness(s_sets, rig, lines, alive, prev_alive)
-      @show (1, alive)
-      # s_sets will be in reverse order as required.
-      for s in s_sets
-        set = getindex(s)
-        if set.id in keys(alive)
-          println("here!!")
-          # id = alive[getindex(s).id]
-          # delete!(alive, getindex(s).id)
-          # @show haskey(lines, id)
-          # push!(lines, set.id => s)
-          push!(lines, set.id => push!(lines[set.id], s))
-        else
-          println("here!, $(set)")
-          push!(skippedsets, s)
+        s_sets = Vector();
+        a_b = liveness_(code[1:i-1], rig, lines, a_b, branches, true, s_sets)
+        # liveness(s_sets, rig, lines, alive, branches)
+        # @show (1, alive)
+        # s_sets will be in reverse order as required.
+        for s in s_sets
+          set = getindex(s)
+          if haskey(a_b, set.id)
+            push!(lines, set.id => push!(lines[set.id], s))
+          else
+            push!(skippedsets, s)
+          end
         end
       end
-
-
-
-      pop!(prev_alive)
+      if x.cond
+        a_f = copy(alive)
+        a_f = liveness_(code[1:i-1], rig, lines, a_f, branches, loop, skippedsets)
+        merge!(a_b, a_f)
+      end
+      alive = a_b
+      break
     end
   end
 
-  if first_pass_loop
+  if loop
     return alive
   elseif !isempty(skippedsets)
     println("Warning: Setting locals but values aren't used (Can replace with Drop).")
-    @show map(getindex, skippedsets), map(s -> s.i, skippedsets)
+    println((map(getindex, skippedsets), map(s -> s.i, skippedsets)))
   end
   return alive
-
-  # return rig
 end
-
-# TODO: Loops. The problem lies in the fact that the same set_local can be used
-# for what might be 2 different value_ids.
-
-# loop
-#   get_local 1 <- some value id from before the loop, or the value id from the set below.
-#    ....
-#   set_local 1 <- creates a new value id.
-# end
-
-# In all other constructs flow control is just sequential down the program, so
-# there's no chance of this happening. It should be possible to perform a trick
-# to fix it such as reformatting so any get performed before a set is done
-# outside of the loop.
 
 using GraphLayout
 function drawGraph(filename, graph)
   # Output the graph
   am = Matrix(adjacency_matrix(graph))
   loc_x, loc_y = layout_spring_adj(am)
+  # draw_layout_adj(am, loc_x, loc_y, filename=filename, arrowlengthfrac=0)
   draw_layout_adj(am, loc_x, loc_y, filename=filename)
 end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -105,7 +105,7 @@ function liveness(func::Func)
   return rig, alive, lines, skippedsets
 end
 
-function liveness_(code, rig::SimpleGraph=[], lines::Vector{Vector{Vector{Int}}}=[], alive::Dict{Int, Int}=[], branches=[], branch=[], loop::Bool=false, skippedsets=Vector())
+function liveness_(code, rig::SimpleGraph=SimpleGraph(), lines::Vector{Vector{Vector{Int}}}=[], alive::Dict{Int, Int}=[], branches=[], branch=[], loop::Bool=false, skippedsets=Vector())
   for i in length(code):-1:1
     x = code[i]
     if x isa Local
@@ -113,7 +113,7 @@ function liveness_(code, rig::SimpleGraph=[], lines::Vector{Vector{Vector{Int}}}
       id = get!(alive, x.id) do
         id = if loop && haskey(branches[end][1], x.id)
           # println("So this happens, $x")
-          branches[end][x.id]
+          branches[end][1][x.id]
         else
           add_vertex!(rig)
           push!(lines, [])
@@ -260,9 +260,11 @@ function allocate_registers(func::Func)
   for s in skippedsets
     set_instr(func, s, Drop())
   end
-
+  @show coloring
+  @show func.params
+  @show func.locals
   locals = func.locals[1:coloring.num_colors-length(func.params)]
-  return Func(func.name, func.params, locals, func.returns, func.body)
+  return Func(func.name, func.params, func.returns, locals, func.body)
 end
 
 using GraphLayout

--- a/src/wasm.jl
+++ b/src/wasm.jl
@@ -83,6 +83,8 @@ struct Return <: Instruction end
 
 struct Unreachable <: Instruction end
 
+struct Drop <: Instruction end
+
 const unreachable = Unreachable()
 
 struct FuncType
@@ -161,6 +163,7 @@ Base.show(io::IO, i::Select)   = print(io, "select")
 Base.show(io::IO, i::Branch)   = print(io, i.cond ? "br_if " : "br ", i.level)
 Base.show(io::IO, i::Return)   = print(io, "return")
 Base.show(io::IO, i::Unreachable) = print(io, "unreachable")
+Base.show(io::IO, i::Drop)     = print(io, "drop")
 
 printwasm(io, x, level) = show(io, x)
 

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -124,7 +124,7 @@ end
 
 @testset "Parse-Interpret" begin
 
-relu_wasm = relu_ifelse_wast
+relu_wasm = relu_ifelse_wasm
 
 relu_wasm_expected = Func(Symbol("#relu_Int64"), [i64], [i64], [], Block([Const(0), Local(0), Local(0), Const(0), Op(i64, :lt_s), Select(), Return()]))
 @test relu_wasm.body.body == relu_wasm_expected.body.body

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -104,11 +104,11 @@ fib(x) = x <= 1 ? 1 : fib(x - 1) + fib(x - 2)
 this(x) = pow(x + 1, x - 1)
 
 function rand_test_wasm(f, wasm_f, n_tests = 50, max = 100)
- for i in 1:n_tests
-   args = [rand(WebAssembly.jltype(typ)) % max for typ in wasm_f.params]
-   WebAssembly.interpretwasm(wasm_f, Dict(), args)[1] != f(args...) && return false
- end
- return true
+  for i in 1:n_tests
+    args = [rand(WebAssembly.jltype(typ)) % max for typ in wasm_f.params]
+    WebAssembly.interpretwasm(wasm_f, Dict(), args)[1] != f(args...) && return false
+  end
+  return true
 end
 
 function rand_test_module(fs, m, n_tests = 50, max = 10)
@@ -138,7 +138,7 @@ relu_wasm_expected = Func(Symbol("#relu_Int64"), [i64], [i64], [], Block([Const(
 root = "test/wast/functions/"
 
 for test in tests
-  @test rand_test_wasm(test[1], test[2])
+  @test rand_test_wasm(test[1], test[2] |> WebAssembly.optimise)
 end
 
 # Sort of test module parsing
@@ -216,6 +216,8 @@ m2 = wast"""
     (return)))
 """
 @test m2.exports == [Export(:this, Symbol("#this_Int64"), :func), Export(:pow, Symbol("#pow_Int64_Int64"), :func), Export(:fib, Symbol("#fib_Int64"), :func)]
+
+map!(WebAssembly.optimise, m2.funcs)
 @test rand_test_module([fib, this, pow], m2)
 
 end


### PR DESCRIPTION
Implemented construction of the liveness / register interference graph for all the local variables. Important for register allocation.

For example here is one for the following : `addTwo(x, y) = (x=x-1)+(x=x+1)+y`

![wheel10](https://user-images.githubusercontent.com/6370456/42736185-a22784f4-8859-11e8-8115-503894ee2029.png)

The middle dot (connected to everything) represents the y value which is live throughout, whereas the x value is lost almost immediately.

Haven't quite figured out how to go about this for loops, will keep thinking. There's a note about the issue I'm having at the end of the commit. One solution might be to pretend they have the same value, forcing them to keep the same register.