### PR TITLE
JS Libraries

### DIFF
--- a/src/WebAssembly.jl
+++ b/src/WebAssembly.jl
@@ -15,6 +15,7 @@ include("looper.jl")
 include("io.jl")
 include("parser.jl")
 include("interpret.jl")
+include("jsmodule.jl")
 
 module Instructions
 

--- a/src/jsmodule.jl
+++ b/src/jsmodule.jl
@@ -1,0 +1,77 @@
+# Helper library to produce a js module that reads in wasm library.
+
+const wtype = """
+function wtype(i) {
+  var t = typeof(i)
+  if (t == "number") {
+    return Number.isInteger(i) ? 'i32' : 'f64'
+  } else if (t == "bigint") {
+    return 'i64';
+  }
+  throw "Unsupported Type: " + i + " :: " + t;
+}
+"""
+
+ffiType(t::Type{Int64}) = "'i64'"
+ffiType(t::Type{Int32}) = "'i32'"
+ffiType(t::Type{Float32}) = "'f32'"
+ffiType(t::Type{Float64}) = "'f64'"
+ffiType(t) = string("[", ffiType(t[2][1]), ", [", join(map(ffiType, t[1]), ", "), "]]")
+
+ffiType(t::Int) = t
+
+function wrapper(efs)
+  wrapper = ["""
+  const library = new ffi.Wrapper({
+  ""","""\n
+  }, {
+    dialect: 'assemblyscript',
+  });
+  """]
+  fs = [string("  ", n, ": ", ffiType(f.typ)) for (n, f) in efs]
+  return string(wrapper[1], join(fs, ", \n"), wrapper[2])
+
+end
+
+function exportfs(m)
+  fs = Dict(f.name => f for f in m.funcs)
+  es = filter(e -> e.typ == :func, m.exports)
+  return map(e -> e.name,es), Dict(e.name => fs[e.internalname] for e in m.exports)
+end
+
+function fetch_(names)
+  fetch = ["""
+  library.fetch_ = library.fetch;
+
+  library.fetch = (f => library.fetch_(f).then(() => {
+  ""","""\n
+  }));
+  """]
+  defs = [string("  ", n, " = library.", n, ".bind(library);") for n in names]
+  # fetch = ["library.fetch('", "').then(() => {\n}).catch(console.error);"]
+  return join(fetch, join(defs, "\n"))
+end
+
+function getbasename(n, f)
+  snd = join(WType.(f.typ[1]), "_")
+  length(n) < length(snd) && return n
+  if n[end-length(snd)+1:end] == snd
+    return n[1:end-length(snd)-1]
+  end
+  return n
+end
+
+function jsmodule(m)
+  names, efs = exportfs(m)
+  defs = wrapper(efs)
+  ns = join(names, ", ")
+  fetch = fetch_(names)
+
+  @show getbasename("addTwo_i32_i32", efs[:addTwo])
+
+  vars = string("var ", ns, ";\n");
+  exports = string("export { ", ns, " };\nexport default library;\n")
+
+  # wrapper(efs)
+  join([defs, vars, fetch, exports], "\n")
+end

--- a/src/jsmodule.jl
+++ b/src/jsmodule.jl
@@ -30,7 +30,6 @@ function wrapper(efs)
   """]
   fs = [string("  ", n, ": ", ffiType(f.typ)) for (n, f) in efs]
   return string(wrapper[1], join(fs, ", \n"), wrapper[2])
-
 end
 
 function exportfs(m)
@@ -48,13 +47,10 @@ function fetch_(names)
   }));
   """]
   defs = [string("  ", n, " = library.", n, ".bind(library);") for n in names]
-  # fetch = ["library.fetch('", "').then(() => {\n}).catch(console.error);"]
   return join(fetch, join(defs, "\n"))
 end
 
-# getbasename(n::Symbol, f) = getbasename(string(n), f)
-
-function getbasename(nbol::Symbol, f)
+function getbasename(nbol, f)
   n = string(nbol)
   snd = join(WType.(f.typ[1]), "_")
   length(n) < length(snd) && return nbol
@@ -89,15 +85,12 @@ end
 function jsmodule(m)
   names, efs = exportfs(m)
   defs = wrapper(efs)
-  # ns = join(names, ", ")
   fetch = fetch_(names)
 
-  # @show getbasename("addTwo_i32_i32", efs[:addTwo])
   tnames, tied = tiefunctions(efs)
 
   vars = string("var ", join(names, ", "), ";\n");
   exports = string("export { ", join(vcat(names, tnames),", "), " };\nexport default library;\n")
 
-  # wrapper(efs)
   join([wtype, defs, vars, fetch, tied, exports], "\n")
 end

--- a/src/wasm.jl
+++ b/src/wasm.jl
@@ -95,6 +95,9 @@ struct Func
   returns::Vector{WType}
   locals::Vector{WType}
   body::Block
+
+  # Store the julia type so we know e.g. whether an i32 is a pointer or a value.
+  typ::Tuple{Vector{DataType},Vector{DataType}}
 end
 
 struct Table


### PR DESCRIPTION
Add support for producing a js library out of a module.

Example output:

```js
function wtype(i) {
  var t = typeof(i)
  if (t == "number") {
    return Number.isInteger(i) ? 'i32' : 'f64'
  } else if (t == "bigint") {
    return 'i64';
  }
  throw "Unsupported Type: " + i + " :: " + t;
}

const library = new ffi.Wrapper({
  addTwo_f64_i32: ['f64', ['f64', 'i32']], 
  addTwo_i32_f64: ['f64', ['i32', 'f64']], 
  addTwo_f64_f64: ['f64', ['f64', 'f64']], 
  addTwo_i32_i32: ['i32', ['i32', 'i32']]
}, {
  dialect: 'assemblyscript',
});

var addTwo_f64_i32, addTwo_i32_f64, addTwo_f64_f64, addTwo_i32_i32;

library.fetch_ = library.fetch;

library.fetch = (f => library.fetch_(f).then(() => {
  addTwo_f64_i32 = library.addTwo_f64_i32.bind(library);
  addTwo_i32_f64 = library.addTwo_i32_f64.bind(library);
  addTwo_f64_f64 = library.addTwo_f64_f64.bind(library);
  addTwo_i32_i32 = library.addTwo_i32_i32.bind(library);
}));

var addTwo = (...a) => eval("addTwo_" + a.map(wtype).join("_") + "(" + a.join() + ")");
library.addTwo = addTwo

export { addTwo_f64_i32, addTwo_i32_f64, addTwo_f64_f64, addTwo_i32_i32, addTwo };
export default library;
```

The library produced by `wasm-ffi` is exported, and the functions are all bound to their own names. `addTwo` is all of the different `addTwo`s tied together, if the name `addTwo` was taken this wouldn't happen. It is also added to the library. I thought about the interface for dealing with the modules and this seems to be a good way. Used like so:

```
import JLAdd, { addTwo } from "./main.js"

JLAdd.fetch('./main.wasm').then(() => {
  console.log(addTwo(400, 400))
})
```
`JLAdd` could be any string, and then functions can be exported by name.

I think it would be safe to make `wtype` return `i32` for anything else as it's probably a pointer if it's not one of those basic types, but it's not necessary yet.