### PR TITLE
use f64 instead of i64

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pow = let
   body = block!(ir)
   ret  = block!(ir)
   n = argument!(cond, n, i32)
-  r = argument!(cond, 1.0, i64)
+  r = argument!(cond, 1.0, f64)
   branch!(cond, ret, unless = push!(cond, stmt(xcall(i32.gt_s, n, Int32(0)), type = i32)))
   n = push!(body, stmt(xcall(i32.sub, n, Int32(1)), type = i32))
   r′ = push!(body, stmt(xcall(f64.mul, r, x), type = f64))


### PR DESCRIPTION
Maybe, `f64` is appropriate type for this example.